### PR TITLE
Fix/catch all conflict

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -92,11 +92,14 @@ func (n *node) addRoute(path string, handle Handle) {
 			}
 
 			// Find the longest common prefix.
-			// This also implies that the common prefix contains no ':' or '*'
-			// since the existing key can't contain those chars.
 			i := 0
 			max := min(len(path), len(n.path))
 			for i < max && path[i] == n.path[i] {
+				if path[i] == '*' {
+					panic("Cannot register '" + fullPath +
+						"'. Segment '" + path[i:] +
+						"' conflicts with existing route '" + n.path[i:])
+				}
 				i++
 			}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -334,6 +334,7 @@ func TestTreeCatchAllConflict(t *testing.T) {
 		{"/src2/*filepath/x", true},
 		{"/src3/*filepath", false},
 		{"/src3/*filepath/x", true},
+		{"/src/*filepath", false},
 	}
 	testRoutes(t, routes)
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -332,6 +332,8 @@ func TestTreeCatchAllConflict(t *testing.T) {
 		{"/src/*filepath/x", true},
 		{"/src2/", false},
 		{"/src2/*filepath/x", true},
+		{"/src3/*filepath", false},
+		{"/src3/*filepath/x", true},
 	}
 	testRoutes(t, routes)
 }


### PR DESCRIPTION
Registering a path segment following a catch-all is disallowed but it is possible to register a path segment following an existing catch-all, e.g. `/src/*filepath/x` is forbidden (via panic), but registering `/src/*filepath` then registering `/src/*filepath/x` works.

This commit fixes this behavior and panics in the second case as well