### PR TITLE
Improve readability of wildcard conflict check

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -143,8 +143,7 @@ func (n *node) addRoute(path string, handle Handle) {
 
 					// Check if the wildcard matches
 					if len(path) >= len(n.path) && n.path == path[:len(n.path)] &&
-						// Check for longer wildcard, e.g. :name and :names
-						(len(n.path) >= len(path) || path[len(n.path)] == '/') {
+						(len(n.path) == len(path) || path[len(n.path)] == '/') {
 						continue walk
 					} else {
 						// Wildcard conflict


### PR DESCRIPTION
Current logic and commentary suggests that it might be allowable to register conflicting path parameters if the name of one parameter prefixes that of the other. 